### PR TITLE
Pin base image to a digest, following jonasbn/ebirah

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
+# check=skip=InvalidDefaultArgInFrom
+
 # REF: https://docs.docker.com/engine/reference/builder/
 # REF: https://hub.docker.com/_/perl
-FROM perl:5.44.0
+# REF: https://github.com/Perl/docker-perl
+ARG BASE_IMAGE=perl:5.44.0@sha256:63050301d917c751d6adc2db7669c0e811d3dc75fa4dbca958ff3080e3caf0fd
+FROM ${BASE_IMAGE}
 
 # We point to the original repository for the image
-LABEL org.opencontainers.image.source https://github.com/jonasbn/caesura
+LABEL org.opencontainers.image.source="https://github.com/jonasbn/caesura"
+LABEL org.opencontainers.image.base.name="registry.hub.docker.com/library/perl:5.44.0"
 
 # We need C compiler and related tools
 ENV DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,21 @@
 # REF: https://docs.docker.com/engine/reference/builder/
 # REF: https://hub.docker.com/_/perl
 # REF: https://github.com/Perl/docker-perl
-ARG BASE_IMAGE=perl:5.44.0@sha256:63050301d917c751d6adc2db7669c0e811d3dc75fa4dbca958ff3080e3caf0fd
+ARG BASE_IMAGE=perl:5.44.0-slim-trixie@sha256:c9aac2fcb8612b25b818df998413423eecf15d8d5175c98d1c10a069ac7e7f8f
 FROM ${BASE_IMAGE}
 
 # We point to the original repository for the image
 LABEL org.opencontainers.image.source="https://github.com/jonasbn/caesura"
-LABEL org.opencontainers.image.base.name="registry.hub.docker.com/library/perl:5.44.0"
+LABEL org.opencontainers.image.base.name="registry.hub.docker.com/library/perl:5.44.0-slim-trixie"
 
-# We need C compiler and related tools
+# We need a C compiler and related tools to build XS modules pulled in by
+# App::pause's dependency tree (e.g. List::MoreUtils -> Test::LeakTrace),
+# which the slim base image does not ship with
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y \
-    && apt-get install -y --no-install-recommends
+    && apt-get install -y --no-install-recommends build-essential \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
 
 # This is our Dist::Zilla work directory, we do not want to mix this
 # with our staging area


### PR DESCRIPTION
## Summary
- Reviewed [`jonasbn/ebirah`'s Dockerfile](https://github.com/jonasbn/ebirah/blob/master/Dockerfile) for its base-image use/pinning conventions and adopted the same patterns here.

**Digest pinning:**
- Replaces the mutable `FROM perl:5.44.0` tag with `ARG BASE_IMAGE=...@sha256:...` + `FROM ${BASE_IMAGE}`, so the build is pinned to an immutable digest rather than a tag that can be silently repointed upstream.
- Adds `org.opencontainers.image.base.name` label to document which tag the pinned digest corresponds to (mirrored from ebirah).
- Adds the `# check=skip=InvalidDefaultArgInFrom` BuildKit checks directive that ebirah uses to suppress the expected warning for this `ARG`-in-`FROM` pattern.
- Quoted the existing `LABEL org.opencontainers.image.source` value to match Docker's current recommended `LABEL key="value"` syntax (also matches ebirah).

**Slim base image + fixed compiler install:**
- Switches the base image to `perl:5.44.0-slim-trixie` (digest pinned, same tag ebirah uses), reducing the final image from ~1.2GB to ~574MB.
- The existing `apt-get install -y --no-install-recommends` line listed **no packages** — it was a dead no-op that only "worked" by accident because the full `perl` image ships a C toolchain by default. `App::pause`'s dependency tree needs one regardless (`List::MoreUtils` → `Test::LeakTrace` is XS), so this was a latent bug on the slim path. Now explicitly installs `build-essential`, fixing the no-op and satisfying the real requirement documented in the adjacent comment.
- Added `apt-get clean` + `rm -rf /var/lib/apt/lists/*` to avoid retaining the apt cache in the image layer.

Not carried over from ebirah (kept out of scope): non-root user setup and the other descriptive OCI labels (`image.title`, `image.description`, `image.url`).

Dependabot's `docker` ecosystem watcher (`.github/dependabot.yml`) already supports `ARG`-based `FROM` and digest-pinned images, so no config changes were needed for it to keep bumping this going forward.

## Test plan
- [x] `docker build -t caesura .` completes successfully with the pinned `perl:5.44.0` digest (before slim switch).
- [x] `docker build -t caesura .` completes successfully with `perl:5.44.0-slim-trixie` + `build-essential` — all 136 CPAN distributions install, including the XS deps that fail without a compiler.
- [x] `docker run --rm caesura --version` reports `pause version 0.662` correctly from the final image.
- [x] Confirmed image size drop: full base ~1.2GB → slim+build-essential ~574MB.